### PR TITLE
Allow use of custom delimiter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,6 +289,9 @@ Running Vlads Programatically
       List of validators. Optional, defaults to the class variable `validators`
       if set, otherwise uses `EmptyValidator` for all fields.
 
+  :``delimiter=','``:
+      The delimiter used within your csv source. Optional, defaults to `,`.
+
   For example:
 
 .. code:: python

--- a/vladiate/examples/bats.csv
+++ b/vladiate/examples/bats.csv
@@ -1,0 +1,4 @@
+Column A|Column B
+Vlad the Impaler|Not A Vampire
+Dracula|Vampire
+Count Chocula|Vampire

--- a/vladiate/examples/vladfile.py
+++ b/vladiate/examples/vladfile.py
@@ -2,6 +2,7 @@ from vladiate import Vlad
 from vladiate.validators import UniqueValidator, SetValidator
 from vladiate.inputs import LocalFile
 
+
 class YourFirstValidator(Vlad):
     source = LocalFile('vampires.csv')
     validators = {
@@ -12,6 +13,20 @@ class YourFirstValidator(Vlad):
             SetValidator(['Vampire', 'Not A Vampire'])
         ]
     }
+
+
+class YourFirstNonCommaDelimitedValidator(Vlad):
+    source = LocalFile('bats.csv')
+    validators = {
+        'Column A': [
+            UniqueValidator()
+        ],
+        'Column B': [
+            SetValidator(['Vampire', 'Not A Vampire'])
+        ]
+    }
+    delimiter = '|'
+
 
 class YourFirstFailingValidator(Vlad):
     source = LocalFile('potential_vampires.csv')
@@ -24,9 +39,11 @@ class YourFirstFailingValidator(Vlad):
         ]
     }
 
+
 class YourFirstEmptyValidator(Vlad):
     source = LocalFile('real_vampires.csv')
     validators = {}
+
 
 class YourSecondEmptyValidator(Vlad):
     source = LocalFile('real_vampires.csv')

--- a/vladiate/main.py
+++ b/vladiate/main.py
@@ -172,7 +172,7 @@ def main():
 
     # validate all the vlads
     for vlad in vlad_classes:
-        vlad(vlad.source, validators=vlad.validators).validate()
+        vlad(vlad.source, validators=vlad.validators, delimiter=vlad.delimiter).validate()
 
 
 if __name__ == '__main__':

--- a/vladiate/test/test_vlads.py
+++ b/vladiate/test/test_vlads.py
@@ -18,6 +18,20 @@ def test_initialize_vlad():
     assert Vlad(source=source, validators=validators).validate()
 
 
+def test_initialize_vlad_with_alternative_delimiter():
+    source = LocalFile('vladiate/examples/bats.csv')
+    validators = {
+        'Column A': [
+            UniqueValidator()
+        ],
+        'Column B': [
+            SetValidator(['Vampire', 'Not A Vampire'])
+        ]
+    }
+    delimiter = '|'
+    assert Vlad(source=source, validators=validators, delimiter=delimiter).validate()
+
+
 def test_initialize_vlad_no_source():
     with pytest.raises(TypeError):
         Vlad().validate()

--- a/vladiate/vlad.py
+++ b/vladiate/vlad.py
@@ -1,4 +1,3 @@
-import sys
 import csv
 from collections import defaultdict
 from vladiate.exceptions import ValidationException
@@ -8,13 +7,15 @@ from vladiate import logs
 
 class Vlad(object):
 
-    def __init__(self, source, validators={}, default_validator=EmptyValidator):
+    def __init__(self, source, validators={}, default_validator=EmptyValidator,
+                 delimiter=None):
         self.logger = logs.logger
         self.failures = defaultdict(lambda: defaultdict(list))
         self.missing_validators = None
         self.missing_fields = None
         self.source = source
         self.validators = validators or getattr(self, 'validators', {})
+        self.delimiter = delimiter or getattr(self, 'delimiter', ',')
 
         self.validators.update({
             field: [default_validator()]
@@ -63,7 +64,7 @@ class Vlad(object):
     def validate(self):
         self.logger.info("\nValidating {}(source={})".format(
             self.__class__.__name__, self.source))
-        reader = csv.DictReader(self.source.open())
+        reader = csv.DictReader(self.source.open(), delimiter=self.delimiter)
 
         self.missing_validators = set(reader.fieldnames) - set(self.validators)
         if self.missing_validators:


### PR DESCRIPTION
When extending the `Vlad` class, one can now choose to set an attribute called `delimiter` that will be used when reading the csv source.

It is optional and if it is unset, it will be defaulted to using  `,` as the separator.

here are some examples where the delimiter is set:

```
class Chocula(Vlad):
    source = LocalFile('...')
    validators = {
        'Column A': [],
        'Column B': []
    }
    delimiter = '|'
```

or 

```
Vlad(source=LocalFile('...'), validators={}, delimiter='|')
```