### PR TITLE
Set vlad_logger level to INFO

### DIFF
--- a/vladiate/logs.py
+++ b/vladiate/logs.py
@@ -1,6 +1,7 @@
 import logging
 
 logger = logging.getLogger("vlad_logger")
+logger.setLevel(logging.INFO)
 sh = logging.StreamHandler()
 sh.setLevel(logging.INFO)
 sh.setFormatter(logging.Formatter('%(message)s'))


### PR DESCRIPTION
Fixes a regression from 9e141cc where INFO logs were not being sent to stdout.