### PR TITLE
Add ignore_missing_validators param

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,6 +312,10 @@ Running Vlads Programatically
   :``delimiter=','``:
       The delimiter used within your csv source. Optional, defaults to `,`.
 
+  :``ignore_missing_validators=False``:
+      Whether to fail validation if there are fields in the file for which the
+      `Vlad` does not have validators. Optional, defaults to `False`.
+
   For example:
 
 .. code:: python

--- a/vladiate/main.py
+++ b/vladiate/main.py
@@ -221,4 +221,5 @@ def run(name):
     if name == '__main__':
         exit(main())
 
+
 run(__name__)

--- a/vladiate/test/test_vlads.py
+++ b/vladiate/test/test_vlads.py
@@ -128,3 +128,19 @@ def test_gt_99_failures():
         }
 
     assert not TestVlad(source=source).validate()
+
+
+def test_ignore_missing_validators():
+    source = LocalFile('vladiate/examples/vampires.csv')
+
+    class TestVlad(Vlad):
+        validators = {
+            'Column A': [
+                UniqueValidator()
+            ],
+        }
+
+    vlad = TestVlad(source=source, ignore_missing_validators=True)
+
+    assert vlad.validate()
+    assert vlad.missing_validators == {'Column B'}


### PR DESCRIPTION
This allows the user to turn off validation failure if there are extra fields in the file for which the `Vlad` does not have validators.