### PR TITLE
RangeValidator updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-__version__ = '0.0.15'
+__version__ = '0.0.16'
 
 
 class PyTest(TestCommand):

--- a/vladiate/test/test_validators.py
+++ b/vladiate/test/test_validators.py
@@ -167,6 +167,14 @@ def test_range_validator_fails():
     assert validator.bad == {'-42'}
 
 
+def test_range_validator_handles_bad_values():
+    validator = RangeValidator(0, 100)
+    with pytest.raises(ValidationException):
+        validator.validate("foobar")
+
+    assert validator.bad == {'foobar'}
+
+
 def test_empty_validator_works():
     EmptyValidator().validate("")
 

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -144,7 +144,11 @@ class RangeValidator(Validator):
         self.outside = set()
 
     def validate(self, field, row={}):
-        if not self.low <= float(field) <= self.high:
+        try:
+            value = float(field)
+            if not self.low <= value <= self.high:
+                raise ValueError
+        except ValueError:
             self.outside.add(field)
             raise ValidationException(
                 "'{}' is not in range {} to {}".format(


### PR DESCRIPTION
Update `RangeValidator` to fail more gracefully when the provided value cannot be cast to a float.