### PR TITLE
Fix flake8 errors: E722 do not use bare except'

### DIFF
--- a/vladiate/inputs.py
+++ b/vladiate/inputs.py
@@ -1,11 +1,11 @@
 import io
 try:
     from urlparse import urlparse
-except:
+except ImportError:
     from urllib.parse import urlparse
 try:
     from StringIO import StringIO
-except:
+except ImportError:
     from io import StringIO
 
 from vladiate.exceptions import MissingExtraException
@@ -45,7 +45,7 @@ class S3File(VladInput):
         try:
             import boto  # noqa
             self.boto = boto
-        except:
+        except ImportError:
             # 2.7 workaround, should just be `raise Exception() from None`
             exc = MissingExtraException()
             exc.__context__ = None

--- a/vladiate/main.py
+++ b/vladiate/main.py
@@ -1,6 +1,6 @@
 try:
     from Queue import Empty
-except:
+except ImportError:
     from queue import Empty
 from multiprocessing import Pool, Queue
 from vladiate import Vlad

--- a/vladiate/test/test_inputs.py
+++ b/vladiate/test/test_inputs.py
@@ -9,7 +9,7 @@ from ..vlad import Vlad
 def mock_boto(result):
     try:
         import builtins
-    except:
+    except ImportError:
         import __builtin__ as builtins
     realimport = builtins.__import__
 

--- a/vladiate/test/test_main.py
+++ b/vladiate/test/test_main.py
@@ -86,7 +86,7 @@ def test_run(monkeypatch):
     monkeypatch.setattr('vladiate.main.main', main)
     try:
         monkeypatch.setattr('__builtin__.exit', exit)
-    except AttributeError:
+    except ImportError:
         monkeypatch.setattr('builtins.exit', exit)
 
     run('__main__')

--- a/vladiate/test/test_main.py
+++ b/vladiate/test/test_main.py
@@ -86,7 +86,7 @@ def test_run(monkeypatch):
     monkeypatch.setattr('vladiate.main.main', main)
     try:
         monkeypatch.setattr('__builtin__.exit', exit)
-    except:
+    except AttributeError:
         monkeypatch.setattr('builtins.exit', exit)
 
     run('__main__')


### PR DESCRIPTION
flake8 reports several "E722 do not use bare except'" errors. The missing `ImportError`s and `AttributeError`s were added.