### PR TITLE
Fix set validator

### DIFF
--- a/vladiate/test/test_validators.py
+++ b/vladiate/test/test_validators.py
@@ -4,7 +4,7 @@ from pretend import stub, call, call_recorder
 from ..validators import (
     CastValidator, EmptyValidator, FloatValidator, Ignore, IntValidator,
     NotEmptyValidator, RangeValidator, RegexValidator, SetValidator,
-    UniqueValidator, Validator, stringify_set
+    UniqueValidator, Validator, _stringify_set
 )
 from ..exceptions import BadValidatorException, ValidationException
 
@@ -227,11 +227,11 @@ def test_all_validators_support_empty_ok(validator_class, args):
     ({}, 0, "{}"),
 ])
 def test_stringify_set(a_set, max_len, stringified):
-    assert stringify_set(a_set, max_len) == stringified
+    assert _stringify_set(a_set, max_len) == stringified
 
 
 def test_stringify_set_invalid_params():
     with pytest.raises(ValueError):
-        stringify_set({}, -1, 10)
+        _stringify_set({}, -1, 10)
     with pytest.raises(ValueError):
-        stringify_set({}, 10, -1)
+        _stringify_set({}, 10, -1)

--- a/vladiate/test/test_validators.py
+++ b/vladiate/test/test_validators.py
@@ -85,7 +85,6 @@ def test_set_validator_works(field_set, field):
     ([], 'bar'),
     (['foo'], 'bar'),
     (['foo', 'bar'], 'baz'),
-    ([str(x) for x in range(200)], "notanumber"),
 ])
 def test_set_validator_fails(field_set, field):
     validator = SetValidator(field_set)

--- a/vladiate/test/test_validators.py
+++ b/vladiate/test/test_validators.py
@@ -4,7 +4,7 @@ from pretend import stub, call, call_recorder
 from ..validators import (
     CastValidator, EmptyValidator, FloatValidator, Ignore, IntValidator,
     NotEmptyValidator, RangeValidator, RegexValidator, SetValidator,
-    UniqueValidator, Validator
+    UniqueValidator, Validator, stringify_set
 )
 from ..exceptions import BadValidatorException, ValidationException
 
@@ -217,3 +217,14 @@ def test_base_class_raises():
 def test_all_validators_support_empty_ok(validator_class, args):
     validator = validator_class(*args, empty_ok=True)
     validator.validate('')
+
+
+@pytest.mark.parametrize('a_set, max_len, stringified', [
+    ({'A', 'B', 'C'}, 4, "{'A', 'B', 'C'}"),
+    ({'A', 'B', 'C'}, 3, "{'A', 'B', 'C'}"),
+    ({'A', 'B', 'C'}, 2, "{'A', 'B'} (1 more suppressed)"),
+    ({'A', 'B', 'C'}, 0, "{} (3 more suppressed)"),
+    ({}, 5, "{}"),
+])
+def test_stringify_set(a_set, max_len, stringified):
+    assert stringify_set(a_set, max_len) == stringified

--- a/vladiate/test/test_validators.py
+++ b/vladiate/test/test_validators.py
@@ -224,6 +224,14 @@ def test_all_validators_support_empty_ok(validator_class, args):
     ({'A', 'B', 'C'}, 2, "{'A', 'B'} (1 more suppressed)"),
     ({'A', 'B', 'C'}, 0, "{} (3 more suppressed)"),
     ({}, 5, "{}"),
+    ({}, 0, "{}"),
 ])
 def test_stringify_set(a_set, max_len, stringified):
     assert stringify_set(a_set, max_len) == stringified
+
+
+def test_stringify_set_invalid_params():
+    with pytest.raises(ValueError):
+        stringify_set({}, -1, 10)
+    with pytest.raises(ValueError):
+        stringify_set({}, 10, -1)

--- a/vladiate/test/test_validators.py
+++ b/vladiate/test/test_validators.py
@@ -224,14 +224,6 @@ def test_all_validators_support_empty_ok(validator_class, args):
     ({'A', 'B', 'C'}, 2, "{'A', 'B'} (1 more suppressed)"),
     ({'A', 'B', 'C'}, 0, "{} (3 more suppressed)"),
     ({}, 5, "{}"),
-    ({}, 0, "{}"),
 ])
 def test_stringify_set(a_set, max_len, stringified):
     assert _stringify_set(a_set, max_len) == stringified
-
-
-def test_stringify_set_invalid_params():
-    with pytest.raises(ValueError):
-        _stringify_set({}, -1, 10)
-    with pytest.raises(ValueError):
-        _stringify_set({}, 10, -1)

--- a/vladiate/test/test_validators.py
+++ b/vladiate/test/test_validators.py
@@ -85,6 +85,7 @@ def test_set_validator_works(field_set, field):
     ([], 'bar'),
     (['foo'], 'bar'),
     (['foo', 'bar'], 'baz'),
+    ([str(x) for x in range(200)], "notanumber"),
 ])
 def test_set_validator_fails(field_set, field):
     validator = SetValidator(field_set)

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -1,4 +1,5 @@
 import re
+from itertools import islice
 
 from vladiate.exceptions import ValidationException, BadValidatorException
 
@@ -215,7 +216,7 @@ def stringify_set(a_set, max_len):
     ''' Stringify `max_len` elements of `a_set` and count the remainings '''
     # Don't convert `a_set` to a list for performance reasons
     text = "[{}]".format(", ".join(
-        "'{}'".format(value) for _, value in zip(range(max_len), a_set)
+        "'{}'".format(value) for value in islice(a_set, max_len)
     ))
     if len(a_set) > max_len:
         text += " ({} more suppressed)".format(len(a_set) - max_len)

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -219,11 +219,6 @@ def _stringify_set(a_set, max_len, max_sort_size=8192):
     Large sets won't be sorted for performance reasons.
     This may result in an arbitrary ordering in the returned string.
     '''
-    if max_len < 0:
-        raise ValueError("max_len must be non-negative: {}".format(max_len))
-    if max_sort_size < 0:
-        raise ValueError(
-            "max_sort_size must be non-negative: {}".format(max_sort_size))
     # Don't convert `a_set` to a list for performance reasons
     text = "{{{}}}".format(", ".join(
         "'{}'".format(value) for value in islice(

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -72,7 +72,7 @@ class SetValidator(Validator):
             self.invalid_set.add(field)
             raise ValidationException(
                 "'{}' is not in {}".format(field,
-                                           stringify_set(self.valid_set, 100)))
+                                           _stringify_set(self.valid_set, 100)))
 
     @property
     def bad(self):
@@ -212,7 +212,7 @@ class Ignore(Validator):
         pass
 
 
-def stringify_set(a_set, max_len, max_sort_size=8192):
+def _stringify_set(a_set, max_len, max_sort_size=8192):
     ''' Stringify `max_len` elements of `a_set` and count the remainings
 
     Small sets (len(a_set) <= max_sort_size) are displayed sorted.

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -212,11 +212,18 @@ class Ignore(Validator):
         pass
 
 
-def stringify_set(a_set, max_len):
-    ''' Stringify `max_len` elements of `a_set` and count the remainings '''
+def stringify_set(a_set, max_len, max_sort_size=8192):
+    ''' Stringify `max_len` elements of `a_set` and count the remainings
+
+    Small sets (len(a_set) <= max_sort_size) are displayed sorted.
+    Large sets won't be sorted for performance reasons.
+    This may result in an arbitrary ordering in the returned string.
+    '''
     # Don't convert `a_set` to a list for performance reasons
     text = "{{{}}}".format(", ".join(
-        "'{}'".format(value) for value in islice(a_set, max_len)
+        "'{}'".format(value) for value in islice(
+            sorted(a_set) if len(a_set) <= max_sort_size else a_set,
+            max_len)
     ))
     if len(a_set) > max_len:
         text += " ({} more suppressed)".format(len(a_set) - max_len)

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -219,6 +219,11 @@ def stringify_set(a_set, max_len, max_sort_size=8192):
     Large sets won't be sorted for performance reasons.
     This may result in an arbitrary ordering in the returned string.
     '''
+    if max_len < 0:
+        raise ValueError("max_len must be non-negative: {}".format(max_len))
+    if max_sort_size < 0:
+        raise ValueError(
+            "max_sort_size must be non-negative: {}".format(max_sort_size))
     # Don't convert `a_set` to a list for performance reasons
     text = "{{{}}}".format(", ".join(
         "'{}'".format(value) for value in islice(

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -70,7 +70,8 @@ class SetValidator(Validator):
         if field not in self.valid_set:
             self.invalid_set.add(field)
             raise ValidationException(
-                "'{}' is not in {}".format(field, self.valid_set))
+                "'{}' is not in {}".format(field,
+                                           stringify_set(self.valid_set, 100)))
 
     @property
     def bad(self):
@@ -208,3 +209,14 @@ class Ignore(Validator):
     @property
     def bad(self):
         pass
+
+
+def stringify_set(a_set, max_len):
+    ''' Stringify `max_len` elements of `a_set` and count the remainings '''
+    # Don't convert `a_set` to a list for performance reasons
+    text = "[{}]".format(", ".join(
+        "'{}'".format(value) for _, value in zip(range(max_len), a_set)
+    ))
+    if len(a_set) > max_len:
+        text += " ({} more suppressed)".format(len(a_set) - max_len)
+    return text

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -215,7 +215,7 @@ class Ignore(Validator):
 def stringify_set(a_set, max_len):
     ''' Stringify `max_len` elements of `a_set` and count the remainings '''
     # Don't convert `a_set` to a list for performance reasons
-    text = "[{}]".format(", ".join(
+    text = "{{{}}}".format(", ".join(
         "'{}'".format(value) for value in islice(a_set, max_len)
     ))
     if len(a_set) > max_len:


### PR DESCRIPTION
Fix the issue with `SetValidator` in #50: The `valid_set` is no longer stringified as a whole instead only the first 100 elements are shown.

Some minor design decisions applied here:
- Don't create any unnecessary lists. Use iterators instead.
- Don't stringify what is not shown.