### PR TITLE
Non-unix exit codes and non-multiprocess exit code fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 80
-exclude = *.egg,.state,build,.tox
+exclude = *.egg,.state,build,.tox,dist
 select = E,W,F,N

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = ['-x', 'vladiate/test']
+        self.pytest_args = ['-x', 'tests']
 
     def finalize_options(self):
         TestCommand.finalize_options(self)

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,9 +1,9 @@
 import pytest
 from pretend import stub, call, call_recorder
 
-from ..exceptions import MissingExtraException
-from ..inputs import S3File, StringIO, String, VladInput
-from ..vlad import Vlad
+from vladiate.exceptions import MissingExtraException
+from vladiate.inputs import S3File, StringIO, String, VladInput
+from vladiate.vlad import Vlad
 
 
 def mock_boto(result):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,20 +1,19 @@
 import os
 import sys
 import inspect
-from vladiate import exits
 
 import pytest
 from pretend import stub, call, call_recorder
 
-from ..main import (  # NOQA
+from vladiate import exits
+from vladiate.examples import vladfile
+from vladiate.examples.vladfile import YourFirstFailingValidator
+from vladiate.inputs import String
+from vladiate.main import (
     parse_args, is_vlad, find_vladfile, load_vladfile, _vladiate, main, run,
     _is_package
 )
-
-from ..vlad import Vlad
-from ..inputs import String
-from ..examples import vladfile
-from ..examples.vladfile import YourFirstFailingValidator
+from vladiate.vlad import Vlad
 
 
 def test_parse_args():
@@ -260,7 +259,7 @@ def test_main_no_vladfile(monkeypatch):
 
 @pytest.mark.parametrize('path, expected', [
     ('foo/bar', False),
-    ('vladiate/test', True),
+    ('vladiate/examples', True),
 ])
 def test_is_package(path, expected):
     assert _is_package(path) == expected

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,12 +1,12 @@
 import pytest
 from pretend import stub, call, call_recorder
 
-from ..validators import (
+from vladiate.exceptions import BadValidatorException, ValidationException
+from vladiate.validators import (
     CastValidator, EmptyValidator, FloatValidator, Ignore, IntValidator,
     NotEmptyValidator, RangeValidator, RegexValidator, SetValidator,
     UniqueValidator, Validator, _stringify_set
 )
-from ..exceptions import BadValidatorException, ValidationException
 
 
 class FakeRow(object):

--- a/tests/test_vlads.py
+++ b/tests/test_vlads.py
@@ -1,11 +1,11 @@
 import pytest
 
-from ..vlad import Vlad
-from ..inputs import LocalFile, String
-from ..validators import (
+from vladiate.inputs import LocalFile, String
+from vladiate.validators import (
     EmptyValidator, FloatValidator, NotEmptyValidator, SetValidator,
     UniqueValidator,
 )
+from vladiate.vlad import Vlad
 
 
 def test_initialize_vlad():

--- a/vladiate/exits.py
+++ b/vladiate/exits.py
@@ -1,0 +1,42 @@
+""" A collection of exit codes that mimic that values returned by LINUX systems """
+import os
+
+__all__ = ['OK', 'NO_INPUT', 'UNAVAILABLE', 'DATAERR']
+_WINDOWS = 'nt'
+
+_OK_CODE = 0
+_DATAERR = 65
+_NOINPUT = 66
+_UNAVAILABLE = 69
+
+
+def on_windows():
+    return os.name == _WINDOWS
+
+
+@property
+def OK():
+    if on_windows():
+        return _OK_CODE
+    return os.EX_OK
+
+
+@property
+def DATAERR():
+    if on_windows():
+        return _DATAERR
+    return os.EX_DATAERR
+
+
+@property
+def NOINPUT():
+    if on_windows():
+        return _OK_CODE
+    return os.EX_NOINPUT
+
+
+@property
+def UNAVAILABLE():
+    if on_windows():
+        return _UNAVAILABLE
+    return os.EX_UNAVAILABLE

--- a/vladiate/exits.py
+++ b/vladiate/exits.py
@@ -1,42 +1,8 @@
-""" A collection of exit codes that mimic that values returned by LINUX systems """
+""" A collection of exit codes that work on non-UNIX systems """
+
 import os
 
-__all__ = ['OK', 'NO_INPUT', 'UNAVAILABLE', 'DATAERR']
-_WINDOWS = 'nt'
-
-_OK_CODE = 0
-_DATAERR = 65
-_NOINPUT = 66
-_UNAVAILABLE = 69
-
-
-def on_windows():
-    return os.name == _WINDOWS
-
-
-@property
-def OK():
-    if on_windows():
-        return _OK_CODE
-    return os.EX_OK
-
-
-@property
-def DATAERR():
-    if on_windows():
-        return _DATAERR
-    return os.EX_DATAERR
-
-
-@property
-def NOINPUT():
-    if on_windows():
-        return _OK_CODE
-    return os.EX_NOINPUT
-
-
-@property
-def UNAVAILABLE():
-    if on_windows():
-        return _UNAVAILABLE
-    return os.EX_UNAVAILABLE
+OK = getattr(os, 'EX_OK', 0)
+DATAERR = getattr(os, 'EX_DATAERR', 65)
+NOINPUT = getattr(os, 'EX_NOINPUT', 66)
+UNAVAILABLE = getattr(os, 'EX_UNAVAILABLE', 69)

--- a/vladiate/main.py
+++ b/vladiate/main.py
@@ -163,7 +163,7 @@ def main():
 
     if arguments.show_version:
         print("Vladiate %s" % (get_distribution('vladiate').version, ))
-        return os.EX_OK
+        return exits.OK
 
     vladfile = find_vladfile(arguments.vladfile)
     if not vladfile:

--- a/vladiate/main.py
+++ b/vladiate/main.py
@@ -5,6 +5,7 @@ except ImportError:
 from multiprocessing import Pool, Queue
 from vladiate import Vlad
 from vladiate import logs
+from vladiate import exits
 
 import os
 import sys
@@ -170,7 +171,7 @@ def main():
             "Could not find any vladfile! Ensure file ends in '.py' and see "
             "--help for available options."
         )
-        return os.EX_NOINPUT
+        return exits.NOINPUT
 
     docstring, vlads = load_vladfile(vladfile)
 
@@ -178,18 +179,18 @@ def main():
         logger.info("Available vlads:")
         for name in vlads:
             logger.info("    " + name)
-        return os.EX_OK
+        return exits.OK
 
     if not vlads:
         logger.error("No vlad class found!")
-        return os.EX_NOINPUT
+        return exits.NOINPUT
 
     # make sure specified vlad exists
     if arguments.vlads:
         missing = set(arguments.vlads) - set(vlads.keys())
         if missing:
             logger.error("Unknown vlad(s): %s\n" % (", ".join(missing)))
-            return os.EX_UNAVAILABLE
+            return exits.UNAVAILABLE
         else:
             names = set(arguments.vlads) & set(vlads.keys())
             vlad_classes = [vlads[n] for n in names]
@@ -211,10 +212,10 @@ def main():
         proc_pool.map(_vladiate, vlad_classes)
         try:
             if not result_queue.get_nowait():
-                return os.EX_DATAERR
+                return exits.DATAERR
         except Empty:
             pass
-        return os.EX_OK
+        return exits.OK
 
 
 def run(name):

--- a/vladiate/test/test_main.py
+++ b/vladiate/test/test_main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import inspect
+from vladiate import exits
 
 import pytest
 from pretend import stub, call, call_recorder
@@ -136,12 +137,12 @@ def test_main_when_get_nowait_raises(monkeypatch):
     monkeypatch.setattr('vladiate.main.result_queue', result_queue)
     monkeypatch.setattr('vladiate.main.Empty', MockEmpty)
 
-    assert main() is os.EX_OK
+    assert main() is exits.OK
 
 
 @pytest.mark.parametrize('get_nowait, expected', [
-    (lambda: stub(), os.EX_OK),
-    (lambda: False, os.EX_DATAERR),
+    (lambda: stub(), exits.OK),
+    (lambda: False, exits.DATAERR),
 ])
 def test_main_with_multiprocess(monkeypatch, get_nowait, expected):
     monkeypatch.setattr(
@@ -236,7 +237,7 @@ def test_main_missing_vlads(monkeypatch):
         'vladiate.main.load_vladfile',
         lambda *args, **kwargs: (None, {'Something Else': stub()})
     )
-    assert main() == os.EX_UNAVAILABLE
+    assert main() == exits.UNAVAILABLE
 
 
 def test_main_no_vlads_loaded(monkeypatch):
@@ -254,7 +255,7 @@ def test_main_no_vlads_loaded(monkeypatch):
     monkeypatch.setattr(
         'vladiate.main.load_vladfile', lambda *args, **kwargs: (None, vlads)
     )
-    assert main() == os.EX_NOINPUT
+    assert main() == exits.NOINPUT
 
 
 def test_main_list_commands(monkeypatch):
@@ -272,21 +273,21 @@ def test_main_list_commands(monkeypatch):
     monkeypatch.setattr(
         'vladiate.main.load_vladfile', lambda *args, **kwargs: (None, vlads)
     )
-    assert main() == os.EX_OK
+    assert main() == exits.OK
 
 
 def test_main_show_version(monkeypatch):
     monkeypatch.setattr(
         'vladiate.main.parse_args', lambda: stub(show_version=True)
     )
-    assert main() == os.EX_OK
+    assert main() == exits.OK
 
 
 def test_main_no_vladfile(monkeypatch):
     monkeypatch.setattr(
         'vladiate.main.find_vladfile', lambda *args, **kwargs: None
     )
-    assert main() == os.EX_NOINPUT
+    assert main() == exits.NOINPUT
 
 
 @pytest.mark.parametrize('path, expected', [

--- a/vladiate/test/test_main.py
+++ b/vladiate/test/test_main.py
@@ -101,50 +101,11 @@ def test_run(monkeypatch):
     ]
 
 
-def test_main_when_get_nowait_raises(monkeypatch):
-    monkeypatch.setattr(
-        'vladiate.main.parse_args', lambda: stub(
-            list_commands=False,
-            show_version=False,
-            vladfile=stub(),
-            vlads=['Something'],
-            processes=2,
-        )
-    )
-    monkeypatch.setattr(
-        'vladiate.main.find_vladfile', lambda *args, **kwargs: stub()
-    )
-    vlad = call_recorder(lambda *args, **kwargs: stub(validate=lambda: stub()))
-    vlad.source = stub()
-
-    monkeypatch.setattr(
-        'vladiate.main.load_vladfile',
-        lambda *args, **kwargs: (None, {'Something': vlad})
-    )
-
-    Pool = call_recorder(
-        lambda *args, **kwargs: stub(map=lambda *args, **kwargs: stub())
-    )
-    monkeypatch.setattr('vladiate.main.Pool', Pool)
-
-    class MockEmpty(BaseException):
-        pass
-
-    def _raise_empty():
-        raise MockEmpty
-
-    result_queue = stub(get_nowait=_raise_empty)
-    monkeypatch.setattr('vladiate.main.result_queue', result_queue)
-    monkeypatch.setattr('vladiate.main.Empty', MockEmpty)
-
-    assert main() is exits.OK
-
-
-@pytest.mark.parametrize('get_nowait, expected', [
-    (lambda: stub(), exits.OK),
+@pytest.mark.parametrize('get, expected', [
+    (lambda: True, exits.OK),
     (lambda: False, exits.DATAERR),
 ])
-def test_main_with_multiprocess(monkeypatch, get_nowait, expected):
+def test_main_with_multiprocess(monkeypatch, get, expected):
     monkeypatch.setattr(
         'vladiate.main.parse_args', lambda: stub(
             list_commands=False,
@@ -169,7 +130,14 @@ def test_main_with_multiprocess(monkeypatch, get_nowait, expected):
         lambda *args, **kwargs: stub(map=lambda *args, **kwargs: stub())
     )
     monkeypatch.setattr('vladiate.main.Pool', Pool)
-    result_queue = stub(get_nowait=get_nowait)
+
+    def empty(calls=[]):
+        if calls:
+            return True
+        calls.append(None)
+        return False
+
+    result_queue = stub(get=get, empty=empty)
     monkeypatch.setattr('vladiate.main.result_queue', result_queue)
 
     assert main() is expected
@@ -195,7 +163,7 @@ def test_main_with_vlads_in_args(monkeypatch):
         'vladiate.main.load_vladfile',
         lambda *args, **kwargs: (None, {'Something': vlad})
     )
-    assert main() is None
+    assert main() is exits.OK
 
 
 def test_main_no_vlads_in_args(monkeypatch):
@@ -218,7 +186,7 @@ def test_main_no_vlads_in_args(monkeypatch):
         'vladiate.main.load_vladfile',
         lambda *args, **kwargs: (None, {'Something Else': vlad})
     )
-    assert main() is None
+    assert main() == exits.OK
 
 
 def test_main_missing_vlads(monkeypatch):


### PR DESCRIPTION
Fixes #48, closes #49, fixes #54.

This PR makes the exit codes work cross-platform, and fixes a bug where the exit codes were not being properly returned when not using multiprocessing.