### PR TITLE
Vladiate enhancements

### DIFF
--- a/vladiate/inputs.py
+++ b/vladiate/inputs.py
@@ -41,7 +41,7 @@ class LocalFile(VladInput):
 class S3File(VladInput):
     ''' Read from a file in S3 '''
 
-    def __init__(self, path=None, bucket=None, key=None):
+    def __init__(self, path=None, bucket=None, key=None, aws_config={}):
         try:
             import boto  # noqa
             self.boto = boto
@@ -50,6 +50,8 @@ class S3File(VladInput):
             exc = MissingExtraException()
             exc.__context__ = None
             raise exc
+        #
+        self.aws_config = aws_config
 
         if path and not any((bucket, key)):
             self.path = path
@@ -67,7 +69,12 @@ class S3File(VladInput):
             )
 
     def open(self):
-        s3 = self.boto.connect_s3()
+        # aws_access_key_id, aws_secret_access_key
+        if self.aws_config:
+            s3 = self.boto.connect_s3(aws_access_key_id=self.aws_config['aws_access_key_id'], aws_secret_access_key=self.aws_config['aws_secret_access_key'])
+        else:
+            s3 = self.boto.connect_s3()
+
         bucket = s3.get_bucket(self.bucket)
         key = bucket.new_key(self.key)
         contents = key.get_contents_as_string()

--- a/vladiate/vlad.py
+++ b/vladiate/vlad.py
@@ -77,7 +77,7 @@ class Vlad(object):
                 for field in sorted(missing_items)])))
 
     def validate(self):
-        self.logger.info("\nValidating {}(source={})".format(
+        self.logger.info("Validating {}(source={})".format(
             self.__class__.__name__, self.source))
 
         if self.fieldnames:
@@ -86,7 +86,7 @@ class Vlad(object):
             reader = csv.DictReader(self.source.open(), delimiter=self.delimiter)
 
         if not reader.fieldnames:
-            self.logger.info("Source file has no field names")
+            self.logger.info("Source file has no field names.")
             return False
 
         self.missing_validators = set(reader.fieldnames) - set(self.validators)


### PR DESCRIPTION
This PR extends the current Vladiate to support our CSV file validation requirements.

The following enhancements have been added

- Ability to overrides or accept custom field names instead of inferring them from CSV header.
- Able to pass S3 credentials to S3File inputs.
- Gzip compressed CSV file support for LocalFile and S3File inputs.
- Add commonly used CSV data types validators.
- Ability to turn off console log.