### PR TITLE
Add support of fullmatch() to RegexValidator.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,6 +245,8 @@ Vladiate comes with a few common validators built-in:
 
   :``pattern=r'di^'``:
       The regex pattern. Fails for all fields by default.
+  :``full=False``:
+      Specify whether we should use a fullmatch() or match().
   :``empty_ok=False``:
       Specify whether a field which is an empty string should be ignored.
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -149,6 +149,13 @@ def test_unique_validator_fails(fields, row, unique_with, exception, bad):
 def test_regex_validator_works(pattern, field):
     RegexValidator(pattern).validate(field)
 
+@pytest.mark.parametrize("pattern, field", [(r"[^\s]+", "foo bar")])
+def test_regex_validator_full_works(pattern, field):
+    validator = RegexValidator(pattern, full=True)
+    with pytest.raises(ValidationException):
+        validator.validate(field)
+
+    assert validator.bad == {field}
 
 @pytest.mark.parametrize("pattern, field", [(r"foo.*", "afoo"), (r"^$", "foo")])
 def test_regex_validator_fails(pattern, field):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -149,6 +149,7 @@ def test_unique_validator_fails(fields, row, unique_with, exception, bad):
 def test_regex_validator_works(pattern, field):
     RegexValidator(pattern).validate(field)
 
+
 @pytest.mark.parametrize("pattern, field", [(r"[^\s]+", "foo bar")])
 def test_regex_validator_full_works(pattern, field):
     validator = RegexValidator(pattern, full=True)
@@ -156,6 +157,7 @@ def test_regex_validator_full_works(pattern, field):
         validator.validate(field)
 
     assert validator.bad == {field}
+
 
 @pytest.mark.parametrize("pattern, field", [(r"foo.*", "afoo"), (r"^$", "foo")])
 def test_regex_validator_fails(pattern, field):

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -124,22 +124,16 @@ class RegexValidator(Validator):
     def __init__(self, pattern=r"di^", full=False, **kwargs):
         super(RegexValidator, self).__init__(**kwargs)
         self.regex = re.compile(pattern)
-        self.full_regex = full
         self.failures = set([])
+        if full:
+            self.regex = re.compile(r'(?:' + pattern + r')\Z')
 
     def validate(self, field, row={}):
-        if not self.full_regex:
-            if not self.regex.match(field) and (field or not self.empty_ok):
-                self.failures.add(field)
-                raise ValidationException(
-                    "'{}' does not match pattern /{}/".format(field, self.regex)
-                )
-        else:
-            if not self.regex.fullmatch(field) and (field or not self.empty_ok):
-                self.failures.add(field)
-                raise ValidationException(
-                    "'{}' does not match pattern /{}/".format(field, self.regex)
-                )
+        if not self.regex.match(field) and (field or not self.empty_ok):
+            self.failures.add(field)
+            raise ValidationException(
+                "'{}' does not match pattern /{}/".format(field, self.regex)
+            )
 
     @property
     def bad(self):

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -121,17 +121,25 @@ class UniqueValidator(Validator):
 class RegexValidator(Validator):
     """ Validates that a field matches a given regex """
 
-    def __init__(self, pattern=r"di^", **kwargs):
+    def __init__(self, pattern=r"di^", full=False, **kwargs):
         super(RegexValidator, self).__init__(**kwargs)
         self.regex = re.compile(pattern)
+        self.full_regex = full
         self.failures = set([])
 
     def validate(self, field, row={}):
-        if not self.regex.match(field) and (field or not self.empty_ok):
-            self.failures.add(field)
-            raise ValidationException(
-                "'{}' does not match pattern /{}/".format(field, self.regex)
-            )
+        if not self.full_regex:
+            if not self.regex.match(field) and (field or not self.empty_ok):
+                self.failures.add(field)
+                raise ValidationException(
+                    "'{}' does not match pattern /{}/".format(field, self.regex)
+                )
+        else:
+            if not self.regex.fullmatch(field) and (field or not self.empty_ok):
+                self.failures.add(field)
+                raise ValidationException(
+                    "'{}' does not match pattern /{}/".format(field, self.regex)
+                )
 
     @property
     def bad(self):

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -123,10 +123,11 @@ class RegexValidator(Validator):
 
     def __init__(self, pattern=r"di^", full=False, **kwargs):
         super(RegexValidator, self).__init__(**kwargs)
-        self.regex = re.compile(pattern)
         self.failures = set([])
         if full:
             self.regex = re.compile(r"(?:" + pattern + r")\Z")
+        else:
+            self.regex = re.compile(pattern)
 
     def validate(self, field, row={}):
         if not self.regex.match(field) and (field or not self.empty_ok):

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -126,7 +126,7 @@ class RegexValidator(Validator):
         self.regex = re.compile(pattern)
         self.failures = set([])
         if full:
-            self.regex = re.compile(r'(?:' + pattern + r')\Z')
+            self.regex = re.compile(r"(?:" + pattern + r")\Z")
 
     def validate(self, field, row={}):
         if not self.regex.match(field) and (field or not self.empty_ok):


### PR DESCRIPTION
On my project, we use `vladiate` to verify the CSV schema containing nginx redirects.
 The `re.match()` does a good job matching part of the string but there are cases when I need to get a definite failure with an expression having a negative match for a full string, i.e in python3.7:

```
import re
expr = re.compile(r'[^\s]+')
expr.fullmatch('foo bar')
```
This PR adds support to `RegexValidator` allowing to pass `full=True` to do a full match, without subclassing the `Validator` manually in one's code. The parameter can be omitted to resemble the original behavior. 