### PR TITLE
changing interpretation of empty_ok for UniqueValidator

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -97,6 +97,7 @@ def test_set_validator_fails(field_set, field):
     [
         ([], {}, []),
         (["foo", "bar"], {}, []),
+        (["foo", ""], {}, []),
         (["foo", "foo"], FakeRow({"some_field": ["bar", "baz"]}), ["some_field"]),
         (
             ["foo", "foo", "foo"],
@@ -129,6 +130,8 @@ def test_unique_validator_supports_empty_ok(fields, row, unique_with):
     "fields, row, unique_with, exception, bad",
     [
         (["foo", "bar", "bar"], {}, [], ValidationException, {("bar",)}),
+        (["foo", "", ""], {}, [], ValidationException, {("",)}),
+        (["", "", ""], {}, [], ValidationException, {("",)}),
         (
             ["foo", "foo"],
             FakeRow({"some_field": ["bar", "bar"]}),

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -117,6 +117,15 @@ def test_unique_validator_works(fields, row, unique_with):
 
 
 @pytest.mark.parametrize(
+    "fields, row, unique_with", [(["foo", "bar", "", ""], {}, []),]
+)
+def test_unique_validator_supports_empty_ok(fields, row, unique_with):
+    validator = UniqueValidator(unique_with=unique_with, empty_ok=True)
+    for field in fields:
+        validator.validate(field, row)
+
+
+@pytest.mark.parametrize(
     "fields, row, unique_with, exception, bad",
     [
         (["foo", "bar", "bar"], {}, [], ValidationException, {("bar",)}),

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -96,6 +96,8 @@ class UniqueValidator(Validator):
         self.unique_check = True
 
     def validate(self, field, row={}):
+        if field == "" and self.empty_ok:
+            return
         if self.unique_with and not self.unique_check:
             self._precheck_unique_with(row)
 


### PR DESCRIPTION
This PR changes the `UniqueValidator` class's interpretation of the `empty_ok` kwarg.

Currently,`empty_ok` allows empty string, but it is considered one of the unique values. There must not be multiple empty string values in a given column.

This implementation ignores empty strings entirely (ie, not counting them as potential duplicates).  That allows the validator to validate a column whose non-empty values are unique, while allowing the values to be empty in some cases.