### PR TITLE
Fix typo in code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -351,7 +351,7 @@ Running Vlads Programatically
 
     from vladiate import Vlad
     from vladiate.inputs import LocalFile
-    Vlad(source=LocalFile('path/to/local/file.csv').validate()
+    Vlad(source=LocalFile('path/to/local/file.csv')).validate()
 
 Testing
 ~~~~~~~


### PR DESCRIPTION
Add missing ")" to programmatic usage example's code.