### PR TITLE
Add instance variable which holds line in which errors happen

### DIFF
--- a/tests/test_vlads.py
+++ b/tests/test_vlads.py
@@ -87,6 +87,7 @@ def test_fails_validation():
     assert not vlad.validate()
     assert vlad.validators["Column A"][0].fail_count == 3
     assert vlad.validators["Column B"][0].fail_count == 3
+    assert vlad.invalid_lines == {1,2,3}
 
 
 def test_gt_99_failures():

--- a/tests/test_vlads.py
+++ b/tests/test_vlads.py
@@ -87,7 +87,7 @@ def test_fails_validation():
     assert not vlad.validate()
     assert vlad.validators["Column A"][0].fail_count == 3
     assert vlad.validators["Column B"][0].fail_count == 3
-    assert vlad.invalid_lines == {1,2,3}
+    assert vlad.invalid_lines == {1, 2, 3}
 
 
 def test_gt_99_failures():

--- a/vladiate/vlad.py
+++ b/vladiate/vlad.py
@@ -26,6 +26,7 @@ class Vlad(object):
         self.line_count = 0
         self.ignore_missing_validators = ignore_missing_validators
         self.logger.disabled = quiet
+        self.failure_lines = set()
 
         self.validators.update(
             {
@@ -123,6 +124,7 @@ class Vlad(object):
                             validator.validate(field, row=row)
                         except ValidationException as e:
                             self.failures[field_name][line].append(e)
+                            setl.failure_lines.add(self.line_count)
                             validator.fail_count += 1
 
         if self.failures:

--- a/vladiate/vlad.py
+++ b/vladiate/vlad.py
@@ -26,7 +26,7 @@ class Vlad(object):
         self.line_count = 0
         self.ignore_missing_validators = ignore_missing_validators
         self.logger.disabled = quiet
-        self.failure_lines = set()
+        self.invalid_lines = set()
 
         self.validators.update(
             {
@@ -124,7 +124,7 @@ class Vlad(object):
                             validator.validate(field, row=row)
                         except ValidationException as e:
                             self.failures[field_name][line].append(e)
-                            setl.failure_lines.add(self.line_count)
+                            self.invalid_lines.add(self.line_count)
                             validator.fail_count += 1
 
         if self.failures:


### PR DESCRIPTION
This PR simply adds the Line number as an instance variable. The test coverage piggy backs from existing tests to show the line numbers are correct.
Using a set ensures no line errors are repeated even if multiple validators find errors in the same line.

Would you like to add the line number to the error log? If so, where do you consider is the best place to be added if at all?