### PR TITLE
Add row level validation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,6 +278,17 @@ Vladiate comes with a few common validators built-in:
 
   Always passes validation. Used to explicity ignore a given column.
 
+*class* ``RowValidator``
+
+  Generic row validator. Should be subclassed by any custom validators. Not
+  to be used directly.
+
+*class* ``RowLengthValidator``
+
+  Validates that each row has the expected number of fields. The expected
+  number of fields is inferred from the CSV header row read by
+  ``csv.DictReader``.
+
 Built-in Input Types
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -11,6 +11,8 @@ from vladiate.validators import (
     NotEmptyValidator,
     RangeValidator,
     RegexValidator,
+    RowValidator,
+    RowLengthValidator,
     SetValidator,
     UniqueValidator,
     Validator,
@@ -253,6 +255,36 @@ def test_base_class_raises():
 
     with pytest.raises(NotImplementedError):
         validator.validate(stub(), stub())
+
+
+def test_row_length_validator_works():
+    validator = RowLengthValidator()
+    validator.validate({"Field One": "1", "Field Two": "Two"})
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {"Field One": "1", "Field Two": None},
+        {"Field One": "1", "Field Two": "2", None: ["3", "4"]},
+    ],
+)
+def test_row_length_validator_fails(row):
+    validator = RowLengthValidator()
+    with pytest.raises(ValidationException):
+        validator.validate(row)
+
+    assert validator.bad == [row]
+
+
+def test_base_row_validator_raises():
+    validator = RowValidator()
+
+    with pytest.raises(NotImplementedError):
+        validator.bad
+
+    with pytest.raises(NotImplementedError):
+        validator.validate(stub())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vlads.py
+++ b/tests/test_vlads.py
@@ -5,6 +5,7 @@ from vladiate.validators import (
     EmptyValidator,
     FloatValidator,
     NotEmptyValidator,
+    RowLengthValidator,
     SetValidator,
     UniqueValidator,
 )
@@ -57,6 +58,18 @@ def test_validators_in_class_variable_are_used():
         }
 
     assert TestVlad(source=source).validate()
+
+
+def test_row_validators():
+    source = LocalFile("vladiate/examples/vampires.csv")
+    row_validators = [RowLengthValidator()]
+    validators = {
+        "Column A": [UniqueValidator()],
+        "Column B": [SetValidator(["Vampire", "Not A Vampire"])],
+    }
+    assert Vlad(
+        source=source, row_validators=row_validators, validators=validators
+    ).validate()
 
 
 def test_missing_validators():


### PR DESCRIPTION
Add the concept of row-level validation and a basic RowLengthValidator as a proof of concept / first use. This change allows for validators that make use of the row as a whole rather than individual fields. The RowLengthValidator demonstrates this by simply checking the length of the row (a dict returned by csv.DictReader); other uses may include interdependent fields (e.g. A and B are both present or both absent).

Resolves #81.