### PR TITLE
Add RowLengthValidator

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -11,6 +11,7 @@ from vladiate.validators import (
     NotEmptyValidator,
     RangeValidator,
     RegexValidator,
+    RowLengthValidator,
     SetValidator,
     UniqueValidator,
     Validator,
@@ -170,6 +171,24 @@ def test_unique_validator_fails(fields, row, unique_with, exception, bad):
             validator.validate(field, row)
 
     assert validator.bad == bad
+
+
+def test_row_length_validator_works():
+    validator = RowLengthValidator()
+    validator.validate("bar", row={"foo": "bar", "baz": "quux"})
+
+
+@pytest.mark.parametrize(
+    "field, row",
+    [
+        ("foo", {"foo": "bar", None: ["baz", "quux"]}),
+        ("foo", {"foo": "bar", "baz": None}),
+    ],
+)
+def test_row_length_validator_fails(field, row):
+    validator = RowLengthValidator()
+    with pytest.raises(ValidationException):
+        validator.validate(row[field], row=row)
 
 
 @pytest.mark.parametrize("pattern, field", [(r"foo.*", "foo"), (r"foo.*", "foobar")])

--- a/vladiate/validators.py
+++ b/vladiate/validators.py
@@ -129,6 +129,45 @@ class UniqueValidator(Validator):
         return self.duplicates
 
 
+class RowLengthValidator(Validator):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.invalid_rows = []
+
+    def validate(self, field, row):
+        # `csv.DictReader` uses its `restkey` attributes to store values
+        # left over after consuming the expected number of values based
+        # on the header row. If the row contains `None` here, that means
+        # the row was longer than expected. Note that this currently
+        # only handles the default value of `None` and does not have
+        # access to the `DictReader` instance to lookup the configured
+        # `restkey` attribute. `vladiate` does not modify this attribute
+        # as of the time of writing this validator, so we use the
+        # default of `None` in our checks. `None` is not an expected
+        # valid key for standard `DictReader` use.
+        if None in row.keys():
+            self.invalid_rows.append(row)
+            expected_length = len(row) - 1
+            length = len(row) + len(row[None]) - 1
+            raise ValidationException(
+                f"Expected {expected_length} fields, got {length}"
+            )
+
+        # Similarly, there is a `csv.DictReader.restval` attribute that
+        # handles the case where there are fewer than expected rows.
+        if None in row.values():
+            self.invalid_rows.append(row)
+            expected_length = len(row)
+            length = len([value for value in row.values() if value is not None])
+            raise ValidationException(
+                f"Expected {expected_length} fields, got {length}"
+            )
+
+    @property
+    def bad(self):
+        return self.invalid_rows
+
+
 class RegexValidator(Validator):
     """Validates that a field matches a given regex"""
 


### PR DESCRIPTION
Contribute the RowLengthValidator discussed in
https://github.com/di/vladiate/issues/81 to the main validators module.

This change should not be made if #82 is going to be completed and accepted. I'm opening this PR as mentioned in #81 in case it makes more sense to keep a validator like this that works without the explicit row-level validation concept.