### PR TITLE
Publish to PyPI via pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+on:
+  release:
+    types:
+      - published
+
+name: Release
+
+permissions:
+  # IMPORTANT: this permission is mandatory for trusted publishing
+  id-token: write
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vladiate
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ">= 3.7"
+
+    - name: Install pypa/build
+      run: python -m pip install build --user
+
+    - name: Build a binary wheel and a source tarball
+      run: python -m build --sdist --wheel --outdir dist/
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Build wheel and sdist artifacts and publish to PyPI when a new release is published via GitHub.

Resolves #80.